### PR TITLE
Add climit import

### DIFF
--- a/parameters.cpp
+++ b/parameters.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "parameters.h"
+#include <climits>
 #include <iostream>
 #include <fstream>
 #include <sstream>


### PR DESCRIPTION
LLONG_MAX is defined in <climits> and not auto-included by a standard build system